### PR TITLE
Refatoração com padrão Observer – Rafael e Kamila

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -12,10 +12,17 @@ O formato baseado em [Keep a Changelog](https://keepachangelog.com/pt-BR/1.0.0/)
 ### Modificado
 - Sem modificações
 
-## [1.1.0] - DATA
+## [1.1.0] - 2025/10/05
 
 ### Adicionado
 
+Implementação do padrão Observer para gerenciar notificações de pedidos.
+
 ### Corrigido
 
+Refatoração da classe PedidoService para desacoplar a lógica de notificação.  
+Substituição de chamadas diretas por observadores, tornando o código mais flexível e de fácil manutenção.
+
 ### Modificado
+
+Código revisado em dupla, seguindo o processo de pair programming.


### PR DESCRIPTION
Descrição da Refatoração  
                                                                                                                                                                                                               O padrão Observer foi aplicado para desacoplar a lógica de criação de pedidos do processo de notificação dos usuários.

Revisão
Solicito revisão do colega Rafael Rodrigues da Mota